### PR TITLE
Add note that other OTP apps can be used

### DIFF
--- a/docs/authenticator_howto.md
+++ b/docs/authenticator_howto.md
@@ -4,6 +4,7 @@ The process to install and set up the Pocket Pass authenticator is in five (5) s
 
 ## <span style="color:red">STEP 1:</span>  Download and install Pocket Pass
 Download and install the **PhenixID Pocket Pass** app on your smartphone.  The correct app is free of charge.
+Although not discussed here, you may use other apps commonly used for two-factor authentication using one-time passwords (OTP).
 
 ### Download for Apple iOS
 


### PR DESCRIPTION
I think it is useful that users know that they can use basically _any_ OTP app (OTP Auth, Google Authenticator, Lastpass etc.), something I only now discovered. I'm storing my token on a YubiKey security key and use Yubico Authenticator. @