### PR TITLE
Update to "On-Demand Applications" to remove Aurora

### DIFF
--- a/docs/manual/faq/manual_faq_software.md
+++ b/docs/manual/faq/manual_faq_software.md
@@ -76,23 +76,6 @@ To gain access to the Amber installation on COSMOS, please submit a [support req
 
 On Aurora we support two MPI libraries: [OpenMPI](https://www.open-mpi.org/) and [Intel MPI](https://software.intel.com/en-us/intel-mpi-library).  Depending on the [toolchain](https://lunarc-documentation.readthedocs.org/en/latest/aurora_modules/#compiling-code-and-using-toolchains) utilised to compile your application different job launchers are required.  Executables build with OpenMPI need to be launched with `mpirun`, while applications build with Intel MPI need to be started with `srun`.  
 
-## The SciPY installed on Aurora fails because of a missing library
-
-This only concerns the SciPY installations build with the Intel compiler.  
-This is a know issue, which we are currently trying to resolve.  If you access SciPY by loading the icc module and the impi module, the Fortran runtime will not be available to Python.  We recommend loading the matching intel module instead of the icc module.  Example:
-```bash
-module load intel/2016b
-module load scipy/0.17.0-Python-2.7.11
-```
-
-## Visual Studio Code (code) doesn't work anymore
-
-Microsofts code editor Visual Studio Code in its latest version uses a runtime library that is no longer suppoerted by CentOS 7. To fix this load the foss module before running Visual Studio Code
-
-```bash
-module load foss
-code
-```
 
 ---
 


### PR DESCRIPTION
I referenced the LUNARC home page. Hopefully the specs are listed in the correct format.
Also, just checking: the GfxLauncher is only available on the GPU nodes, right?