### PR TITLE
Cleaning up broken links, deprecated toolchains, and other outdated references

### DIFF
--- a/docs/guides/containers/apptainer.md
+++ b/docs/guides/containers/apptainer.md
@@ -71,14 +71,14 @@ There are two main parts to any definition file, each of which contains several 
 1. The **Header**, which describes the OS that the contained software is to run within and where the template for that OS kernel is located. The header must include a `Bootstrap` key-value pair, which determines which other key-value pairs must be included in the header. The full list of available bootstrap agents can be found [in this section of the Apptainer documentation](https://apptainer.org/docs/user/latest/definition_files.html#preferred-bootstrap-agents). The other keywords made available with the use of each agent can be found by clicking the name of the bootstrap agent, if it is highlighted as a hyperlink.
    
 2. **Sections**, which include all other code needed to build the container. Each section must be prefaced with a title, all lower-case, that starts with `%`, like `%post` or `%environment`. All sections are optional and there can be more than one instance of each section in one .def file. Sections run at build time are executed with the `/bin/sh` interpreter and accept `/bin/sh` options. The full list of available sections can be found [in the Sections chapter of the Apptainer documentation](https://apptainer.org/docs/user/latest/definition_files.html#sections). The most important sections you are likely to use are:
-   
-   - `%files`: this section lets you copy files into the container. Note that Apptainer as configured on our system mounts your home directory, so files there do not need to be copied into the container.
-     
-   - `%post`: this section is where you give the commands to download and install software into the container. By default, the commands will be in either `sh` or `bash`, but if you wanted to change the shell language to, for example, `tcsh`, you could start the section as `%post -c tcsh`. Environmental variables that must be defined at *build* time must also be placed here.
-     
-   - `%environment`: this section lets you set *runtime* environmental variables to be used in the container. Environmental variables are not copied from the host, but some may be set within the container by any software installations done in `%post`.
-
-   - `%runscript`: this section is written to a dedicated file at build time and then, at run time, its contents execute when the container is run directly. Any options passed upon running the container will be passed to `%runscript`. Very often this section will contain a line that says something like ` <app_name> "$@" `. The `"$@"` expands all the arguments passed after the container name in `apptainer run <container> [args...]` and forwards them to the program executed inside the container at runtime.
+    
+    - `%files`: this section lets you copy files into the container. Note that Apptainer as configured on our system mounts your home directory, so files there do not need to be copied into the container.
+      
+    - `%post`: this section is where you give the commands to download and install software into the container. By default, the commands will be in either `sh` or `bash`, but if you wanted to change the shell language to, for example, `tcsh`, you could start the section as `%post -c tcsh`. Environmental variables that must be defined at *build* time must also be placed here.
+      
+    - `%environment`: this section lets you set *runtime* environmental variables to be used in the container. Environmental variables are not copied from the host, but some may be set within the container by any software installations done in `%post`.
+      
+    - `%runscript`: this section is written to a dedicated file at build time and then, at run time, its contents execute when the container is run directly. Any options passed upon running the container will be passed to `%runscript`. Very often this section will contain a line that says something like ` <app_name> "$@" `. The `"$@"` expands all the arguments passed after the container name in `apptainer run <container> [args...]` and forwards them to the program executed inside the container at runtime.
   
 Once the definition file is finished, you can just run the `build` command to create the .sif like you would for a premade .def file. Once you have the .sif file, running the container is the same as described for premade containers.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,25 +14,17 @@ Here you will find all of the documentation for the LUNARC resources in a easy t
 
     [:fontawesome-solid-question: Frequently asked questions](manual/faq/manual_faq_login.md){: .md-button }
 
-=== "I have used HPC resources before"
-
-    [:fontawesome-solid-jet-fighter-up:  User's Guide](manual/manual_intro/){: .md-button }
-
-    [:material-application: Specific applications](guides/applications/Python){: .md-button }
-
-    [:fontawesome-solid-question: Frequently asked questions](manual/faq/manual_faq_login.md){: .md-button }
-
-=== "I am an expert HPC user"
+=== "Experienced with HPC"
 
     [:fontawesome-solid-jet-fighter-up: User's Guide](manual/manual_intro/){: .md-button }
 
-    [:material-book-open-variant: Application guides](guides/guides_intro){: .md-button }
-
     [:material-application: Specific applications](guides/applications/Python){: .md-button }
+
+    [:material-book-open-variant: Application guides](guides/guides_intro){: .md-button }
 
     [:fontawesome-solid-question: Frequently asked questions](manual/faq/manual_faq_login.md){: .md-button }
 
-=== "I develop HPC software"
+=== "Developing HPC software"
 
     [:material-database-cog: Software development guides](guides/software_development/compiler_options/){: .md-button }
 

--- a/docs/manual/example_job_scripts/manual_example_basic_serial.md
+++ b/docs/manual/example_job_scripts/manual_example_basic_serial.md
@@ -41,7 +41,7 @@ other file systems available. The following script assumes the program processor
 
 The script copies the input data and the program executable from the submission directory to the node local disk executes the program on the node local disk and copies the result file back to the submission directory for safekeeping. The individual steps are highlighted by comments starting with a “#”. These comment lines can be kept in the file.
 
-You need to customise the file to suit your specific needs. The script is suitable for jobs consuming no more than 3100 MB of main memory on Aurora.
+You need to customise the file to suit your specific needs. The script is suitable for jobs consuming no more than 5300 MB of main memory on COSMOS.
 
 ```bash
 #!/bin/bash
@@ -60,14 +60,14 @@ You need to customise the file to suit your specific needs. The script is suitab
 cat $0
 
 # load the modules required for you program - customise for your program
-module load foss/2016a
+module load foss/2023a
 
 # copy the input data and program to node local disk
 # customise for your input file(s) and program name
-cp -p input.dat processor $SNIC_TMP
+cp -p input.dat processor $NAISS_TMP
 
 # change to the execution directory
-cd $SNIC_TMP
+cd $NAISS_TMP
 
 # run the program
 # customise for your program name and add arguments if required
@@ -84,11 +84,11 @@ and result files you need to modify the copy statements accordingly.
 
 ## Module loading
 
-The above examples assume your program has been compiled with the foss/2016a tool-chain module. If it has been compiled with a different compiler or tool chain you need to load the compiler module by adding a line similar to
+The above examples assume your program has been compiled with the foss/2023a tool-chain module. If it has been compiled with a different compiler or tool chain you need to load the compiler module by adding a line similar to, for example,
 
-    module add intel/12.1
+    module add imkl/2023.1.0
 
-LUNARC-provided modules on Aurora are only visible once the required compiler or combination of compiler and MPI library is loaded. If you are using software another person has compiled for you need to consult with that person on the required modules to load. 
+LUNARC-provided modules on COSMOS are only visible once the required compiler or combination of compiler and MPI library is loaded. If you are using software another person has compiled for you need to consult with that person on the required modules to load. 
 
 On other services, the modules typically complain if the wrong compiler is loaded and are hence self-documenting.
 
@@ -129,4 +129,4 @@ Rscript my_r_script.R
 (LUNARC)
 
 **Last Updated:**
-2022-10-05
+2024-06-18

--- a/docs/manual/example_job_scripts/manual_example_openmp_shared_memory.md
+++ b/docs/manual/example_job_scripts/manual_example_openmp_shared_memory.md
@@ -25,13 +25,13 @@ cat $0
 ./processor_omp
 ```
 
-This script allows using 3100 MB of main memory per requested core. Then asking for 20 cores on Aurora you can use all the memory available to users on the node.
+This script allows using 5300 MB of main memory per requested core. Then asking for 20 cores on COSMOS you can use all the memory available to users on the node.
 
 The modification required to utilise the node local discs is the same as required [for serial](#basicrun-script-for-io-intensive-jobs) jobs](#basicrun-script-for-io-intensive-jobs).
 
 ## Thread binding for OpenMP codes
 
-The Aurora nodes deploy a cache-coherent non-uniform-memory access architecture (cc-numa). Many scientific simulation codes gain significant performance benefits on a cc-numa architecture when the user binds the threads to the physical cores of the hardware. This inhibits thread migration and improves memory locality. In the latest OpenMP standards thread binding has been standardised. In addition, many compilers offer their binding syntax.
+The COSMOS nodes deploy a cache-coherent non-uniform-memory access architecture (cc-numa). Many scientific simulation codes gain significant performance benefits on a cc-numa architecture when the user binds the threads to the physical cores of the hardware. This inhibits thread migration and improves memory locality. In the latest OpenMP standards thread binding has been standardised. In addition, many compilers offer their binding syntax.
 
 ### Thread binding with the GNU compilers
 

--- a/docs/manual/faq/manual_faq_files.md
+++ b/docs/manual/faq/manual_faq_files.md
@@ -2,7 +2,7 @@
 
 ## I accidentally deleted or modified a file
 
-For the home space on Aurora, we have **snapshots** enabled.  If you type `ls .snapshots` at the commandline in the current directory you get to see a number of diretories named like `@-2020.12.11-00.00.35`, which stands for the date and time of the snapshot.  Change into the directory specifying a point of time before the accident, e.g.:
+For the home space on COSMOS, we have **snapshots** enabled.  If you type `ls .snapshots` at the commandline in the current directory you get to see a number of diretories named like `@-2020.12.11-00.00.35`, which stands for the date and time of the snapshot.  Change into the directory specifying a point of time before the accident, e.g.:
 
 ```
 cd .snapshots/@-2020.12.11-00.00.35

--- a/docs/manual/faq/manual_faq_jobs.md
+++ b/docs/manual/faq/manual_faq_jobs.md
@@ -8,9 +8,9 @@ We allow batch jobs to ask for up to 168 hours, which is 7 days.
 
 When using a Lund University project (LU project), you have to specify the project name, the partition and in some cases a reservation.  This is explained in our [batch system guide](https://lunarc-documentation.readthedocs.io/en/latest/batch_system/#specifying-a-project-and-partition-for-users-with-lu-projects-or-multiple-projects).
 
-## I want to use the Aurora GPU nodes
+## I want to use the COSMOS GPU nodes
 
-To access the Aurora GPU nodes, you need to be a member of an [LU local project](https://supr.snic.se/round/2020locallu/). Please review our [batch system guide](https://lunarc-documentation.readthedocs.io/en/latest/batch_system/#accessing-gpus-in-the-aurora-lu-partition) for the required modification to your submission script.  The [software guide](https://lunarc-documentation.readthedocs.io/en/latest/aurora_modules/#cuda-based-toolchains-for-gpu-nodes) provides an overview on Compiler, Cuda and MPI support for the GPU nodes. 
+To access the COSMOS GPU nodes, you need to be a member of an [LU local project](https://supr.snic.se/round/2020locallu/). Please review our [batch system guide](https://lunarc-documentation.readthedocs.io/en/latest/manual/submitting_jobs/manual_specifying_requirements/#accessing-gpus-in-the-lu-partition) for the required modification to your submission script.  The [software guide](https://lunarc-documentation.readthedocs.io/en/latest/manual/manual_modules_toolchains/#cuda-based-toolchains-for-gpu-nodes) provides an overview on Compiler, Cuda and MPI support for the GPU nodes. 
 
 ## Can I prevent my job from restarting in case of a node failure
 
@@ -22,8 +22,9 @@ to the header portion of your job script prevents this behaviour.
 
 ---
 
-**Author:**
+**Authors:**
 Joachim Hein (LUNARC)
+Rebecca Pitts (LUNARC)
 
 **Last Updated:**
 2022-08-31

--- a/docs/manual/faq/manual_faq_software.md
+++ b/docs/manual/faq/manual_faq_software.md
@@ -2,54 +2,56 @@
 
 ## Could you please install software for me
 
-Many packages that were installed in standard locations have now been moved to the module system.  Please search for the package using **module spider** before contacting the helpdesk.
+Many packages that were installed in standard locations have been moved to the module system.  Please search for the package using **module spider** before contacting the helpdesk.
 
-## I can not find my software package in the module system
+## I cannot find my software package in the module system
 
 On LUNARC resources a hierarchical module naming scheme is deployed.  This is explained in the [Using installed software guide](/../manual/manual_modules/).  Please contact [LUNARC support](/../about/contact/) if you cannot locate your package with the **module spider** command.
 
 ## Loading a module unloads pre-requisites from a previously loaded module
 
-Many software modules have complex pre-requisites. If you load multiple modules is can happen that they try to load conflicting modules as pre-requisites.  In this case the module loaded last unloads conflicting pre-requisistes from earlier loaded modules.  If that happens, the earlier loaded modules can become disfunctional and there is no guaranty that they still work.
+Many software modules have complex pre-requisites. If you load multiple modules, they may try to load conflicting modules as pre-requisites.  In this case the module loaded last purges conflicting pre-requisistes from previously loaded modules.  If that happens, the modules loaded earlier can become dysfunctional and there is no guarantee that they will still work.
 
-You have the follwing options to resolve the issues:
+You have the following options to resolve the issues:
 
- * Have a look, whether there are different versions of the modules installed that have common pre-requisites.  Acutally in many cases we have the same version of the software installed with different pre-requisites to help this issue.
+ * Have a look at whether there are different versions of the modules installed that have common pre-requisites.  In many cases we have the same version of the software installed with different pre-requisites to help this issue.
  * Have a terminal dedicated to each of the modules.  This should work if the modules do not really interact with each other, but e.g. one module creates files which the other module reads.  Consider using the [Lunarc HPC desktop](https://lunarc-documentation.readthedocs.io/en/latest/using_hpc_desktop/) which easily allows having multiple terminals within a single session
  * If this does not work or does not work satisfactory, contact the [LUNARC helpdesk](http://www.lunarc.lu.se/support/support_form) and discuss your situation.
 
  
-## My application fails because is can't find libgfortran.so.3
-If you jobs fails with an error message similar to
+## My application fails because it can't find libgfortran.so.3
+If your jobs fails with an error message like
 
 ```
 error while loading shared libraries: libgfortran.so.3: cannot
 open shared object file: No such file or directory
 ```
-you are using software that has been compiled with a really old version of GCC.  Please recompile you program on COSMOS using a modern version of GCC.  Preferably a GCC version we provided as a module.
+you are using software that has been compiled with a deprecated version of GCC.  Please recompile you program on COSMOS using a newer version of GCC, preferably a GCC version we provided as a module.
 
 ## I need LAPACK and BLAS - they used to be in /usr/lib64
 
-Using an optimised BLAS library is important for achieving good performance.  The libraries in `/usr/lib64` are typically not highly optimised.  We currently support [OpenBLAS](https://www.openblas.net/) within the foss [toolchain](http://lunarc-documentation.readthedocs.org/en/latest/aurora_modules/#compiling-code-and-using-toolchains) and [MKL](https://software.intel.com/en-us/intel-mkl) in the intel, iomkl and gimkl toolchains.  Both libraries show excellent performance when e.g. used to build HPL (high performance linpack).
+Using an optimised BLAS library is important for achieving good performance.  The libraries in `/usr/lib64` are typically not highly optimised.  We currently support [OpenBLAS](https://www.openblas.net/) within the foss [toolchain](https://lunarc-documentation.readthedocs.io/en/latest/manual/manual_modules_toolchains/) and [MKL](https://software.intel.com/en-us/intel-mkl) in the intel, iomkl, and gimkl toolchains.  Both libraries show excellent performance when e.g. used to build HPL (high performance linpack).
 
 When using OpenBLAS, please be aware that you might [need to control the number of threads](#my-mpi-code-using-openblas-does-not-perform) spawned.
 
 
-## How do I link my code against the MKL installation provided on Aurora
+## How do I link my code against the MKL installation provided on COSMOS
 
-The Aurora modules providing MKL set the environment variable `MKLROOT` to assist the compiler in locating the library on the system.  To link your application we suggest consulting the [Intel® Math Kernel Library Link Line Advisor](https://software.intel.com/en-us/articles/intel-mkl-link-line-advisor) for the arguments needed. 
+The COSMOS modules providing MKL set the environment variable `MKLROOT` to assist the compiler in locating the library on the system.  To link your application we suggest consulting the [Intel® Math Kernel Library Link Line Advisor](https://software.intel.com/en-us/articles/intel-mkl-link-line-advisor) for the arguments needed. 
 
 
-## My MPI code using OpenBLAS does not perform
+## My MPI code using OpenBLAS runs slowly / does not perform as expected
 
-OpenBLAS as installed in the foss [toolchains](https://lunarc-documentation.readthedocs.org/en/latest/aurora_modules/#compiling-code-and-using-toolchains) is compiled with thread support.  When OpenBLAS is used on Aurora, it will typically figure how many cores you are allocated on that node and spawn as many threads.  If this is not desirable (e.g. pure MPI code) you need to control the number of threads spawned by setting the `OMP_NUM_THREADS` variable.  For example for an MPI code running as many tasks as cores requested this is typically be set to:
+OpenBLAS as installed in the foss [toolchains](https://lunarc-documentation.readthedocs.io/en/latest/manual/manual_modules_toolchains/#currently-provided-toolchains) is compiled with thread support.  When OpenBLAS is used on COSMOS, it will typically figure how many cores you are allocated on that node and spawn as many threads.  If this is not desirable (e.g. pure MPI code) you need to control the number of threads spawned by setting the `OMP_NUM_THREADS` variable.  For example for an MPI code running as many tasks as cores requested this is typically be set to:
 ```bash
 export OMP_NUM_THREADS=1
 ```
 
-## I like to run VASP on Aurora but it doesn't work
+For more information on compiling MPI code, 
 
-If you like to use VASP on Aurora, please ensure that you are registed on a license with the VASP developers in Vienna. To comply with the terms of our handling license, we have to confirm the validity of your license with the VASP developers before granting access. That will take normally take a few days but can take weeks under bad circumstances. Being named in a SUPR VASP group does not imply you are entitled to use VASP.
+## I want to run VASP on COSMOS but it doesn't work
+
+If you would like to use VASP on COSMOS, please ensure that you are registed on a license with the VASP developers in Vienna. To comply with the terms of our handling license, we have to confirm the validity of your license with the VASP developers before granting access. That will take normally take a few days but can take weeks under bad circumstances. **Being named in a SUPR VASP group does not imply you are entitled to use VASP.**
 
 After registerering with the VASP team, contact the [LUNARC helpdesk](http://www.lunarc.lu.se/support/support_form) and provide the following information:
 
@@ -59,10 +61,10 @@ After registerering with the VASP team, contact the [LUNARC helpdesk](http://www
 * Your name as stated on the license
 * Whether you require VASP 4 or VASP 5 access
 
-In order to be able to continue the provision of VASP to our ligitimate VASP users, we will not make any exception. 
+In order to be able to continue the provision of VASP to our legitimate VASP users, we cannot make any exceptions. 
 
 
-The VASP5 executables on Aurora are compiled using Intel MPI.  They need to be started with `srun`.  The VASP6 executable is build with OpenMPI.   These executables need to be started with `mpirun`.  Refer to the sample section of our batch [system guide](https://lunarc-documentation.readthedocs.io/en/latest/batch_system/#mpi-job-using-20-tasks-per-node) for a more comprehensive discussion.
+The VASP5 executables on COSMOS are compiled using Intel MPI.  They need to be started with `srun`.  The VASP6 executable is build with OpenMPI.   These executables need to be started with `mpirun`.  Refer to the sample section of our batch [system guide](https://lunarc-documentation.readthedocs.io/en/latest/manual/example_job_scripts/manual_example_mpi_20_tasks/) for a more comprehensive discussion.
 
 ## I need access to Amber
 
@@ -74,7 +76,7 @@ To gain access to the Amber installation on COSMOS, please submit a [support req
 
 ## My MPI application doesn't launch
 
-On Aurora we support two MPI libraries: [OpenMPI](https://www.open-mpi.org/) and [Intel MPI](https://software.intel.com/en-us/intel-mpi-library).  Depending on the [toolchain](https://lunarc-documentation.readthedocs.org/en/latest/aurora_modules/#compiling-code-and-using-toolchains) utilised to compile your application different job launchers are required.  Executables build with OpenMPI need to be launched with `mpirun`, while applications build with Intel MPI need to be started with `srun`.  
+On COSMOS we support two MPI libraries: [OpenMPI](https://www.open-mpi.org/) and [Intel MPI](https://software.intel.com/en-us/intel-mpi-library).  Depending on the [toolchain](https://lunarc-documentation.readthedocs.io/en/latest/manual/manual_modules_toolchains/#currently-provided-toolchains) utilised to compile your application different job launchers are required.  Executables build with OpenMPI need to be launched with `mpirun`, while applications build with Intel MPI need to be started with `srun`.  
 
 
 ---

--- a/docs/manual/faq/manual_faq_software.md
+++ b/docs/manual/faq/manual_faq_software.md
@@ -47,7 +47,7 @@ OpenBLAS as installed in the foss [toolchains](https://lunarc-documentation.read
 export OMP_NUM_THREADS=1
 ```
 
-For more information on compiling MPI code, 
+For more information, see also the LUNARC manual page on [compiling MPI code with a toolchain.](https://lunarc-documentation.readthedocs.io/en/latest/manual/manual_modules_toolchains/#compiling-mpi-code-using-a-toolchain)
 
 ## I want to run VASP on COSMOS but it doesn't work
 

--- a/docs/manual/manual_modules.md
+++ b/docs/manual/manual_modules.md
@@ -2,8 +2,7 @@
 
 ## Hierarchical module naming scheme
 
-With the start of the Aurora service, LUNARC is using a hierarchical module naming scheme.  Hierarchical modules ensure that the correct shared libraries are available when running an application while keeping the screen output of standard module commands such as **module avail** manageable.
-
+Starting with the Aurora service and continuing with COSMOS, LUNARC uses a hierarchical module naming scheme.  Hierarchical modules ensure that the correct shared libraries are available when running an application while keeping the screen output of standard module commands such as **module avail** manageable.
 ### Hierarchical naming scheme concept
 
 When logging into the system, you only get access to those modules that do not require any special dynamic libraries.  After *loading a compiler module* you obtain access to those packages that have been built with that specific compiler and depend on its shared libraries. For many compilers, this will include one or more matching MPI libraries.  After loading an MPI library additional software packages, depending on this pair (compiler & MPI library), will become available.  Users should take note that in many cases loading an MPI library is required for software that doesn't depend on it.

--- a/docs/manual/manual_modules_toolchains.md
+++ b/docs/manual/manual_modules_toolchains.md
@@ -1,6 +1,6 @@
 # Compiling code and using toolchains
 
-A significant portion of the Aurora software is built using the [EasyBuild](http://hpcugent.github.io/easybuild/) software framework.  This framework provides so-called _Toolchains_ which are utilised to build software.  LUNARC recommends using toolchains when building software.  This includes compiling your software outside the EasyBuild framework.
+A significant portion of the COSMOS software is built using the [EasyBuild](http://hpcugent.github.io/easybuild/) software framework.  This framework provides so-called _Toolchains_ which are utilised to build software.  LUNARC recommends using toolchains when building software.  This includes compiling your software outside the EasyBuild framework.
 
 ## Currently provided toolchains
 
@@ -11,23 +11,25 @@ A significant portion of the Aurora software is built using the [EasyBuild](http
     * **GCC**: GCC
     * **foss**: GCC, OpenMPI, OpenBLAS, FFTW, BLACS, ScaLAPACK
     * **gompi**: GCC, OpenMPI
-    * **gimpi**: GCC, Intel MPI
-    * **gimkl**: GCC, Intel MPI, MKL
+    * **gomkl**: GCC, OpenMPI, MKL
+    * **gfbf**: GCC, FlexiBLAS, FFTW  (no MPI)
 
 === "Intel compiler toolchains"
 
-    * **iccifort**: icc, ifort
     * **intel**: icc, ifort, Intel MPI, MKL
     * **iimpi**: icc, ifort, Intel MPI
-    * **iomkl**: icc, ifort, OpenMPI, MKL
+<!---    * **iomkl**: icc, ifort, OpenMPI, MKL
     * **iompi**: icc, ifort, OpenMPI
+    * **iccifort**: icc, ifort
+    ml spider didn't find those last 3--->
 
-=== "PGI compiler toolchains"
+<!---
+=== "PGI compiler toolchains" <--these no longer appear to be supported on COSMOS
  
     * **PGI**: PGI
     * **pompi**: PGI, OpenMPI
     * **pomkl**: PGI, OpenMPI, MKL
-
+--->
 ## CUDA based toolchains for GPU nodes
 
 === "GCC compiler toolchains for GPU"
@@ -48,10 +50,9 @@ If you require additional toolchains, contact [LUNARC support](http://www.lunarc
 
 The above choices of toolchains are a bit overwhelming, in particular for new users.  We recommend first choosing a toolchain and then selecting a version.  Good choices for general use are the toolchains:
 
-* **foss**, if you like to use the GCC compiler suite
-* **gimkl**, if you like to use the GCC compiler suite with Intel's MKL performance library
-* **intel**, if you like to use the Intel compiler suite
-* **pomkl**, if you like to use the PGI compiler suite
+* **foss**, if you want to use the GCC compiler suite
+* **gomkl**, if you want to use the GCC compiler suite with Intel's MKL performance library
+* **intel**, if you want to use the Intel compiler suite
 
 **Example:** To check the foss versions available you
 
@@ -73,10 +74,10 @@ Use "module keyword key1 key2 ..." to search for all possible
 modules matching any of the "keys".
 ```
 
-This shows you that three versions of the foss toolchain are available, with version 2016a being the default.  The version numbering at the time of writing is a *time stamp*.  Version 2015a was released at the beginning of 2015, 2015b in the middle of 2015 and 2016a at the beginning of 2016.  If you load e.g. the `foss/2016a` module
+This shows you that three versions of the foss toolchain are available, with version 2016a being the default.  The version numbering at the time of writing is a *time stamp*.  Version 2022a was released at the beginning of 2022, 2022b in the middle of 2022 and 2023a at the beginning of 2023.  If you load e.g. the `foss/2023a` module
 
 ```bash
-module load foss/2016a
+module load foss/2023a
 ```
 
 It will load several modules for you, incl. compiler, libraries and utilities.  The command 
@@ -109,12 +110,12 @@ If you have loaded a toolchain build use the following commands to compile.
     * **icpc**: C++ compiler
     * **ifort**: Fortran compiler
 
-=== "PGI Toolchain"
+<!---=== "PGI Toolchain"
 
     * **pgcc**: C compiler
     * **pgc++**: C++ compiler
     * **pgf90**: Fortran compiler
-    * **pgf77**: Fortran77 compiler
+    * **pgf77**: Fortran77 compiler--->
  
 In all cases please do not forget about compiler options, in particular optimisation flags.  You should have the toolchain used for compiling loaded when executing the code.
 
@@ -130,7 +131,7 @@ When using a toolchain utilising **OpenMPI** (e.g. foss, iomkl, pomkl) use:
  * **mpicxx** or **mpic++*: MPI compiler for C++ code
  * **mpifort**: MPI compiler for Fortran code
  
-Inside your slurm job-script, executables build with OpenMPI need to get started using the **mpirun** command.  For MPI jobs not using threads, we recommend using task binding.  A simple job script for standard MPI jobs (no threads, e.g. OpenMP) is available on Aurora
+Inside your slurm job-script, executables build with OpenMPI need to get started using the **mpirun** command.  For MPI jobs not using threads, we recommend using task binding.  A simple job script for standard MPI jobs (no threads, e.g. OpenMP) is available on COSMOS:
 
 ```bash
 /sw/pkg/submissionsScripts/script_openmpi.sh
@@ -150,7 +151,7 @@ When using a toolchain utilising the **Intel MPI library** and the **Intel compi
 * **mpiicpc**: MPI compiler for C++ code
 * **mpiifort**: MPI compiler for Fortran code
  
-Inside your slurm job-script, executables build with the Intel MPI library need to get started using the `srun` command.  Task binding is still under investigation and not yet available. For a simple job script for standard MPI jobs is available on Aurora:
+Inside your slurm job-script, executables build with the Intel MPI library need to get started using the `srun` command.  Task binding is still under investigation and not yet available. For a simple job script for standard MPI jobs is available on COSMOS:
 
 ```bash
 /sw/pkg/submissionsScripts/script_intelmpi.sh
@@ -175,4 +176,4 @@ Executable builds using this setup are also started with the **srun** command fr
 (LUNARC)
 
 **Last Updated:**
-2022-10-05
+2024-06-18

--- a/docs/manual/manual_quick_reference.md
+++ b/docs/manual/manual_quick_reference.md
@@ -54,7 +54,7 @@ The amount of memory per core is specified in the format
 
 COSMOS has nodes with 256 GB of memory. The default allocation per core is therefore 5300 MB, allowing some memory for the operating system.  Please note that if you increase your memory request beyond 5300 MB per core, some cores on the system will be idle due to the lack of memory.  Your account gets charged for these cores as well.
 
-Aurora has standard nodes with 64 GB of memory. The default allocation per core is therefore 3200 MB, allowing some memory for the operating system.
+Aurora is being decommissioned, so users are encouraged to shift existing projects to COSMOS and not start any new projects on Aurora. For legacy users' reference, Aurora has standard nodes with 64 GB of memory. The default allocation per core is therefore 3200 MB, allowing some memory for the operating system.
 
 ## File systems
 
@@ -98,5 +98,5 @@ It is not allowed to submit long series of jobs to a test queue.
 (LUNARC)
 
 **Last Updated:**
-2023-01-31
+2024-06-18
 


### PR DESCRIPTION
Lots of stuff changed this time: the documentation page I was advised to share with a prospective VASP user had a ton of outdated info and several of the links were broken. One thing led to another and I ended up cleaning all of the manual files. 

I also tried one more time to fix the formatting of the Apptainer docs. If this doesn't work, I'll reformat Headers and Sections as new sub-subheadings instead of a list. 

Lastly, I also simplified the index page to merge the contents of the "expert users" section and "I have used HPC resources before", because I recall there being some frustration with that being "more clever than helpful" at a group meeting while one of my senior colleagues tried to figure out which sub-heading contained a particular header. 